### PR TITLE
Fix iOS Firebase/Analytics pod version using 6.5.1

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -46,7 +46,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods>
-                <pod name="Firebase/Analytics" spec="~> 6.23.0" />
+                <pod name="Firebase/Analytics" spec="~> 6.5.1" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
Use the latest Firebase/Analytics pod version from https://github.com/CocoaPods/Specs/tree/master/Specs/e/2/1/FirebaseAnalytics to resolve https://github.com/chemerisuk/cordova-plugin-firebase-analytics/issues/157.