### PR TITLE
Change FirebaseAnalytics subspec name

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -46,7 +46,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods>
-                <pod name="Firebase/Analytics" spec="~> 6.5.1" />
+                <pod name="FirebaseAnalytics" spec="~> 6.5.1" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
Use the `FirebaseAnalytics` pod spec name that the main Firebase pod references as a dependency: https://github.com/CocoaPods/Specs/blob/master/Specs/0/3/5/Firebase/6.25.0/Firebase.podspec.json#L34