### PR TITLE
Remove Firebase/Analytics version pinning

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -46,7 +46,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods>
-                <pod name="FirebaseAnalytics" spec="~> 6.5.1" />
+                <pod name="Firebase/Analytics" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
Since this is the recommended approach & seems to behave better in the presence of other plugins with dependencies on Firebase modules.